### PR TITLE
Add Fedora support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # puppet-library
 
-This is a simple tool to help installing Puppet modules with [librarian-puppet](https://github.com/rodjek/librarian-puppet). It is designed to be used in a single run bootstap and currently supports only Ubuntu servers.
+This is a simple tool to help installing Puppet modules with [librarian-puppet](https://github.com/rodjek/librarian-puppet). It is designed to be used in a single run bootstap and currently supports only Ubuntu and Fedora.
+
+Puppet is not supported yet in Fedora 22 and above (https://tickets.puppetlabs.com/browse/CPR-167), but this tool should work on it after puppet gets fixed.
 
 Define puppetfile as explained in librarian-puppet's instructions. Example:
 ```

--- a/library.pp
+++ b/library.pp
@@ -1,11 +1,17 @@
-package { [ 'ruby-dev', 'git', 'make' ]:
-        ensure => 'present',
+$ruby_dev_pkg = $::osfamily ? {
+  'RedHat' => 'ruby-devel',
+  'Debian' => 'ruby-dev',
+  default  => undef,
+}
+
+package { [ $ruby_dev_pkg, 'git', 'make', 'findutils' ]:
+        ensure   => 'present',
 }
 
 package { 'librarian-puppet':
         ensure   => 'installed',
         provider => 'gem',
-        require  => Package['ruby-dev', 'git', 'make'],
+        require  => Package[$ruby_dev_pkg, 'git', 'make', 'findutils'],
 }
 
 exec { 'init-librarian':


### PR DESCRIPTION
Ruby-dev package name is different between the distros. I noticed in minimal docker container that findutils is also needed. The findutils package name is the same both in Debian and Red Hat deriatives.

Unfortunately puppet doesn't support Fedora 22 and above quite yet due the missing dnf support. It's under work though and otherwise this tool works. https://tickets.puppetlabs.com/browse/PUP-4055
